### PR TITLE
Support #disable_inline_form_errors FAPI property

### DIFF
--- a/config/install/errorstyle.settings.yml
+++ b/config/install/errorstyle.settings.yml
@@ -1,0 +1,1 @@
+disable_inline_form_errors: 0

--- a/config/schema/errorstyle.schema.yml
+++ b/config/schema/errorstyle.schema.yml
@@ -1,0 +1,9 @@
+# Schema for the configuration files of the errorstyle module.
+
+errorstyle.settings:
+  type: config_object
+  label: 'ErrorStyle settings'
+  mapping:
+    disable_inline_form_errors:
+      type: integer
+      label: 'Disable Inline Form Errors'

--- a/errorstyle.info.yml
+++ b/errorstyle.info.yml
@@ -2,3 +2,4 @@ name: Error Style
 description: Provides form to test errors on various form elements.
 core: 8.x
 type: module
+configure: errorstyle.settings

--- a/errorstyle.routing.yml
+++ b/errorstyle.routing.yml
@@ -7,3 +7,11 @@ errorstyle.form:
     _permission: 'access content'
   options:
     _admin_route: TRUE
+
+errorstyle.settings:
+  path: 'admin/config/errorstyle'
+  defaults:
+    _form: 'Drupal\errorstyle\Form\ErrorStyleSettingsForm'
+    _title: 'Errorstyle settings'
+  requirements:
+    _permission: 'access administration pages'

--- a/src/Form/ErrorStyleForm.php
+++ b/src/Form/ErrorStyleForm.php
@@ -47,6 +47,13 @@ class ErrorStyleForm extends FormBase {
    * Builds a form for a single entity field.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('errorstyle.settings');
+
+    // Disable Inline Form Errors as neceessary.
+    if ($config->get('disable_inline_form_errors')) {
+      $form['#disable_inline_form_errors'] = TRUE;
+    }
+
     // Prevent browsers HTML5 error checking.
     $form['#attributes'] += array('novalidate' => TRUE);
 

--- a/src/Form/ErrorStyleForm.php
+++ b/src/Form/ErrorStyleForm.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\errorstyle\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a forms with (all) common form elements.
@@ -12,6 +14,25 @@ use Drupal\Core\Form\FormStateInterface;
  * @ingroup form_api
  */
 class ErrorStyleForm extends FormBase {
+
+  /**
+   * Constructs a \Drupal\errorstyle\ErrorStyleForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->setConfigFactory($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
 
   /**
    * {@inheritdoc}

--- a/src/Form/ErrorStyleSettingsForm.php
+++ b/src/Form/ErrorStyleSettingsForm.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\errorstyle\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configure ErrorStyle settings for this site.
+ */
+class ErrorStyleSettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructs a \Drupal\user\StatisticsSettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'errorstyle_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['errorstyle.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('errorstyle.settings');
+
+    $form['disable_inline_form_errors'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Disable Inline Form Errors'),
+      '#default_value' => $config->get('disable_inline_form_errors'),
+      '#description' => t('Do not show inline form errors for the ErrorStyle form.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('errorstyle.settings')
+      ->set('disable_inline_form_errors', $form_state->getValue('disable_inline_form_errors'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Form/ErrorStyleSettingsForm.php
+++ b/src/Form/ErrorStyleSettingsForm.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ErrorStyleSettingsForm extends ConfigFormBase {
 
   /**
-   * Constructs a \Drupal\user\StatisticsSettingsForm object.
+   * Constructs a \Drupal\errorstyle\ErrorStyleSettingsForm object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.


### PR DESCRIPTION
This PR provides a setting, so we can choose whether to apply the proposed `$form['#disable_inline_form_errors']` property to the `error-style/form` page.

Intended for testing Drupal 8 core issue: 
  [#2856950: Add a possibility to disable inline form errors for a complete form](https://www.drupal.org/node/2856950)

Changes:
 - a new settings form controller + route
 - simple config install + schema
 - conditionally sets `$form['#disable_inline_form_errors']`