### PR TITLE
Add menu link for config page.

### DIFF
--- a/errorstyle.links.menu.yml
+++ b/errorstyle.links.menu.yml
@@ -1,0 +1,5 @@
+errorstyle.settings:
+  title: Error Style
+  description: 'Settings for Error Style test forms.'
+  route_name: errorstyle.settings
+  parent: system.admin_config_development


### PR DESCRIPTION
This  PR adds `errorstyle.links.menu.yml` file.

I keep forgetting where I put the admin page, and I needed to toggle the setting for `#disable_inline_form_errors` a lot this week :-)