### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/errorstyle.info.yml
+++ b/errorstyle.info.yml
@@ -1,5 +1,6 @@
 name: Error Style
 description: Provides form to test errors on various form elements.
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: module
 configure: errorstyle.settings


### PR DESCRIPTION
I scanned this module using `drupal/upgrade_status`.

Good news - there is no deprecated code in use.

So all this needs for Drupal 9 compatibility is to add `core_version_requirement: ^8 || ^9` to the info file.