### PR TITLE
Correct composer vendor namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zolhorvath/errorstyle",
+    "name": "dmsmidt/errorstyle",
     "description": "Provides form to test errors on various form elements.",
     "type": "drupal-module",
     "license": "GPL-2.0-or-later"


### PR DESCRIPTION
This module is tricky to install using composer, because the vendor namespace in the `composer.json` file doesn't match the vendor namespace for the VCS repository.

To use the module currently needs these steps:

1. Edit your `composer.json`, to add a VCS repo named `dmsmidt/errorstyle`...
  ```
    "repositories": [
        {
            "type": "composer",
            "url": "https://packages.drupal.org/8"
        },
        {
            "type": "vcs",
            "url": "https://github.com/dmsmidt/errorstyle"
        },
      ],
  ```
2. Then `composer require --dev zolhorvath/errorstyle`, which is a different vendor namespace. That's a bit of a head-scratcher.

This pull request makes the vendor name in composer.json match the repository name.